### PR TITLE
Prevent duplicate queue jobs after timeout

### DIFF
--- a/bertrend/bertrend_apps/services/queue_management/bertrend_worker.py
+++ b/bertrend/bertrend_apps/services/queue_management/bertrend_worker.py
@@ -307,11 +307,23 @@ class BertrendWorker:
 
             logger.info(f"Request endpoint: {request_data.get('endpoint')}")
 
-            # Process request with a timeout to avoid blocking the queue indefinitely
-            response_data = await asyncio.wait_for(
-                self.process_request(request_data),
+            # Handlers delegate synchronous work to threads. Cancelling the
+            # awaiting coroutine does not stop that work, so republishing on a
+            # timeout would execute the same job concurrently. Treat the timeout
+            # as a warning threshold and keep the message unacknowledged until the
+            # original work finishes.
+            request_task = asyncio.create_task(self.process_request(request_data))
+            done, _ = await asyncio.wait(
+                {request_task},
                 timeout=self.config.job_timeout,
             )
+            if not done:
+                logger.warning(
+                    f"Message {correlation_id} exceeded the "
+                    f"{self.config.job_timeout}s job timeout; waiting for the "
+                    "original work to finish to avoid duplicate execution"
+                )
+            response_data = await request_task
 
             # Add metadata
             response_data["correlation_id"] = correlation_id
@@ -321,14 +333,6 @@ class BertrendWorker:
             logger.error(f"Invalid message format: {str(e)}")
             # Reject and don't requeue invalid messages
             await message.reject(requeue=False)
-            return
-
-        except asyncio.TimeoutError:
-            await self._nack_or_discard(
-                message,
-                reason=f"job timed out after {self.config.job_timeout}s",
-                correlation_id=correlation_id,
-            )
             return
 
         except Exception as e:

--- a/bertrend/bertrend_apps/services/queue_management/rabbitmq_config.py
+++ b/bertrend/bertrend_apps/services/queue_management/rabbitmq_config.py
@@ -39,5 +39,6 @@ class RabbitMQConfig:
     max_retries: int = int(os.getenv("RABBITMQ_MAX_RETRIES", 2))
     retry_delay: int = int(os.getenv("RABBITMQ_RETRY_DELAY", 5000))  # milliseconds
 
-    # Job timeout: max seconds a single job may run before being nacked (default: 1 hour)
+    # Soft timeout: warn when a job exceeds this duration, but keep waiting because
+    # cancelling asyncio.to_thread does not stop its synchronous work.
     job_timeout: int = int(os.getenv("RABBITMQ_JOB_TIMEOUT", 3600))

--- a/bertrend/tests/services/queue_management/test_bertrend_worker.py
+++ b/bertrend/tests/services/queue_management/test_bertrend_worker.py
@@ -5,7 +5,7 @@
 
 """
 Unit tests for BertrendWorker.callback() — focusing on:
-  1. Job timeout: a hung process_request is cancelled and the message is nacked.
+  1. Job timeout: uncancellable work is not duplicated after the warning threshold.
   2. Queue blocking: with prefetch_count=1 an unacked message blocks subsequent
      messages from being delivered (RabbitMQ behaviour, simulated here).
   3. Retry limit: messages are rejected to DLQ after max_retries attempts.
@@ -18,7 +18,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from bertrend.bertrend_apps.services.queue_management.bertrend_worker import (
+    ENDPOINT_HANDLERS,
     BertrendWorker,
+)
+from bertrend.bertrend_apps.services.bertrend.models.bertrend_app_models import (
+    TrainNewModelRequest,
 )
 from bertrend.bertrend_apps.services.queue_management.rabbitmq_config import (
     RabbitMQConfig,
@@ -51,7 +55,7 @@ def _make_message(
     return msg
 
 
-def _make_worker(job_timeout: int = 5) -> BertrendWorker:
+def _make_worker(job_timeout: float = 5) -> BertrendWorker:
     config = RabbitMQConfig(job_timeout=job_timeout)
     worker = BertrendWorker(config)
     # Replace queue_manager with a mock so no real RabbitMQ connection is needed
@@ -62,34 +66,57 @@ def _make_worker(job_timeout: int = 5) -> BertrendWorker:
 
 
 # ---------------------------------------------------------------------------
-# Test 1 — Timeout: hung process_request is cancelled, message is nacked
+# Test 1 — Timeout: synchronous work is not duplicated while still running
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_callback_nacks_on_timeout():
+async def test_callback_does_not_retry_uncancellable_work_after_timeout():
     """
-    When process_request takes longer than job_timeout, the message must be
-    republished with incremented retry count and the original rejected (not acked).
+    Crossing the timeout must not republish work delegated to a thread because
+    cancelling the awaiting coroutine does not stop the underlying thread.
     """
-    worker = _make_worker(job_timeout=1)  # 1-second timeout for fast test
+    worker = _make_worker(job_timeout=0.01)
     worker.queue_manager.republish_with_retry = AsyncMock(return_value=True)
+    work_started = asyncio.Event()
+    release_work = asyncio.Event()
 
-    async def slow_handler(request_data):
-        await asyncio.sleep(10)  # much longer than timeout
-        return {"status": "success", "response": {}}
+    async def uncancellable_work():
+        work_started.set()
+        await release_work.wait()
+        return {"result": "completed"}
+
+    async def uncancellable_handler(request):
+        # asyncio.to_thread has the same cancellation boundary: cancelling the
+        # awaiter does not stop the work it is awaiting.
+        return await asyncio.shield(uncancellable_work())
 
     msg = _make_message(
-        {"endpoint": "/train-new-model", "method": "POST", "json_data": {}}
+        {
+            "endpoint": "/train-new-model",
+            "method": "POST",
+            "json_data": {"user": "alice", "model_id": "model-1"},
+        }
     )
 
-    with patch.object(worker, "process_request", side_effect=slow_handler):
-        await worker.callback(msg)
+    with patch.dict(
+        ENDPOINT_HANDLERS,
+        {"/train-new-model": (uncancellable_handler, TrainNewModelRequest)},
+    ):
+        callback_task = asyncio.create_task(worker.callback(msg))
+        try:
+            await asyncio.wait_for(work_started.wait(), timeout=1)
+            await asyncio.sleep(0.05)
 
-    worker.queue_manager.republish_with_retry.assert_awaited_once_with(msg, 0)
-    msg.reject.assert_awaited_once_with(requeue=False)
-    msg.ack.assert_not_awaited()
-    msg.nack.assert_not_awaited()
+            assert not callback_task.done()
+            worker.queue_manager.republish_with_retry.assert_not_awaited()
+            msg.reject.assert_not_awaited()
+            msg.ack.assert_not_awaited()
+        finally:
+            release_work.set()
+            await asyncio.wait_for(callback_task, timeout=1)
+
+    msg.ack.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------
@@ -258,35 +285,6 @@ async def test_nack_or_discard_rejects_at_max_retries():
     )
 
     with patch.object(worker, "process_request", side_effect=failing_handler):
-        await worker.callback(msg)
-
-    worker.queue_manager.republish_with_retry.assert_awaited_once_with(msg, 2)
-    msg.reject.assert_awaited_once_with(requeue=False)
-    msg.nack.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_timeout_rejects_at_max_retries():
-    """
-    A timed-out message that has already reached max_retries must be rejected
-    to the DLQ. republish_with_retry returns False (limit reached) and
-    reject(requeue=False) is still called.
-    """
-    worker = _make_worker(job_timeout=1)
-    worker.config.max_retries = 2
-    # Simulate limit already reached: republish_with_retry returns False
-    worker.queue_manager.republish_with_retry = AsyncMock(return_value=False)
-
-    async def slow_handler(request_data):
-        await asyncio.sleep(10)
-        return {"status": "success", "response": {}}
-
-    msg = _make_message(
-        {"endpoint": "/train-new-model", "method": "POST", "json_data": {}},
-        headers={"x-retry-count": 2},
-    )
-
-    with patch.object(worker, "process_request", side_effect=slow_handler):
         await worker.callback(msg)
 
     worker.queue_manager.republish_with_retry.assert_awaited_once_with(msg, 2)

--- a/docs/services/queue_architecture.md
+++ b/docs/services/queue_architecture.md
@@ -119,9 +119,15 @@ flowchart TB
 1. **Decoupled Scheduling**: Scheduler doesn't need to know about RabbitMQ; it just makes standard HTTP calls.
 2. **Asynchronous Processing**: API endpoints respond instantly while heavy tasks run in the background.
 3. **Priority Queue**: Requests can have priority 1-10 (higher = more urgent), set by the FastAPI router.
-4. **Sequential Processing**: Workers process messages based on `prefetch_count` (usually 1) to manage resource usage.
+4. **Bounded Processing**: Each worker processes up to `prefetch_count` messages (default: 1). Total concurrency is
+   the worker process count multiplied by this value; `supervisord.conf` starts two workers by default.
 5. **Direct Core Execution**: Workers call internal library functions directly, avoiding overhead and potential
    recursive loops with the API.
 6. **Dead Letter Queue**: Failed messages after max retries go to `bertrend_failed` for manual inspection.
 7. **Correlation IDs**: Track request-response pairs across the asynchronous flow.
 8. **Durable Queues**: Messages survive RabbitMQ restarts.
+
+`RABBITMQ_JOB_TIMEOUT` is a soft warning threshold. The worker keeps an overlong
+message unacknowledged until its synchronous work finishes because Python cannot
+safely cancel work already running in a thread. Actual failures still use the
+bounded retry and dead-letter flow.


### PR DESCRIPTION
## Summary

- keep overlong queue jobs unacknowledged until their original work completes
- treat `RABBITMQ_JOB_TIMEOUT` as a warning threshold instead of retrying active work
- document how worker count and RabbitMQ prefetch bound total concurrency
- replace timeout-retry tests with a regression test for uncancellable work

Closes #63.

## Root cause

BERTrend's queue handlers run synchronous model and GPU work through
`asyncio.to_thread`. `asyncio.wait_for` cancelled only the awaiting coroutine;
the underlying thread continued running. The worker then republished the same
message, allowing retries to overlap the original job and bypass the queue's
intended resource limit.

The RabbitMQ worker pool already provides a process-wide capacity boundary,
unlike an `asyncio.Semaphore`, which would be local to each of the two supervisor
processes. With the default prefetch of 1, the two configured workers permit at
most two active jobs.

## Impact

Crossing the configured threshold now emits a warning and keeps the worker slot
occupied until the original job finishes. Actual completed failures still use
the existing bounded retry and dead-letter flow. A genuinely stuck synchronous
job therefore occupies its worker rather than launching duplicate GPU work.

## Validation

- `27 passed` across both queue test suites
- Ruff format check passed for all changed Python files
- Ruff lint passed for all changed Python files
- `git diff --check` passed
