### PR TITLE
feat(prospective-demo): configure zero-shot topics per model

### DIFF
--- a/bertrend/BERTopicModel.py
+++ b/bertrend/BERTopicModel.py
@@ -274,6 +274,11 @@ class BERTopicModel:
 
             logger.debug("\tFitting BERTopic model")
             topics, probs = topic_model.fit_transform(docs, embeddings)
+            zeroshot_labels = {
+                topic: label
+                for topic, label in topic_model.topic_labels_.items()
+                if label in (self.config["bertopic_model"]["zeroshot_topic_list"] or [])
+            }
 
             if not topic_model._outliers:
                 logger.warning("\tNo outliers to reduce.")
@@ -308,6 +313,7 @@ class BERTopicModel:
                 )
                 topic_model.representation_model = backup_representation_model
 
+            topic_model.topic_labels_.update(zeroshot_labels)
             logger.success("\tBERTopic model fitted successfully")
             output = BERTopicModelOutput(topic_model)
             output.topics = new_topics

--- a/bertrend/BERTrend.py
+++ b/bertrend/BERTrend.py
@@ -992,6 +992,8 @@ def train_new_data(
     embedding_service: EmbeddingService,
     granularity: int,
     language: str,
+    zeroshot_topic_list: list[str] | None = None,
+    zeroshot_min_similarity: float | None = None,
 ) -> BERTrend:
     """
     Process new data for incremental trend analysis.
@@ -1010,6 +1012,11 @@ def train_new_data(
         Number of days to group documents.
     language : str
         Language of the text data.
+    zeroshot_topic_list : list[str] or None, optional
+        Expected topics used to guide topic modeling. When omitted, the existing
+        model configuration is preserved.
+    zeroshot_min_similarity : float or None, optional
+        Minimum similarity for assigning documents to an expected topic.
 
     Returns
     -------
@@ -1043,6 +1050,12 @@ def train_new_data(
         else:
             bertrend = BERTrend(topic_model=BERTopicModel())
         bertrend.config["granularity"] = granularity
+
+    if zeroshot_topic_list is not None:
+        bertopic_config = bertrend.topic_model.config["bertopic_model"]
+        bertopic_config["zeroshot_topic_list"] = zeroshot_topic_list or None
+        if zeroshot_min_similarity is not None:
+            bertopic_config["zeroshot_min_similarity"] = zeroshot_min_similarity
 
     # Embed new data
     embeddings, token_strings, token_embeddings = embedding_service.embed(

--- a/bertrend/bertrend_apps/prospective_demo/__init__.py
+++ b/bertrend/bertrend_apps/prospective_demo/__init__.py
@@ -35,6 +35,8 @@ DEFAULT_ANALYSIS_CFG = {
         "window_size": DEFAULT_WINDOW_SIZE,
         "language": DEFAULT_LANGUAGE,
         "split_by_paragraph": True,
+        "zeroshot_topic_list": [],
+        "zeroshot_min_similarity": 0.7,
     },
     "analysis_config": {
         "topic_evolution": True,

--- a/bertrend/bertrend_apps/prospective_demo/i18n_translations.py
+++ b/bertrend/bertrend_apps/prospective_demo/i18n_translations.py
@@ -455,6 +455,26 @@ TRANSLATIONS = {
         "fr": "Sélection de la plage temporelle considérée pour calculer les différents types de signaux (faibles, forts)",
         "en": "Selection of the time range considered to calculate different types of signals (weak, strong)",
     },
+    "zeroshot_topics_label": {
+        "fr": "Sujets attendus (zéro-shot, facultatif)",
+        "en": "Expected topics (zero-shot, optional)",
+    },
+    "zeroshot_topics_placeholder": {
+        "fr": "Un sujet à suivre par ligne",
+        "en": "One topic to monitor per line",
+    },
+    "zeroshot_topics_help": {
+        "fr": "Saisissez un sujet par ligne pour guider la détection vers des thèmes connus. Laissez vide pour une découverte entièrement non supervisée. La modification s'applique aux nouveaux modèles.",
+        "en": "Enter one topic per line to guide detection toward known themes. Leave empty for fully unsupervised discovery. Changes apply to newly trained models.",
+    },
+    "zeroshot_min_similarity_label": {
+        "fr": "Similarité minimale avec les sujets attendus",
+        "en": "Minimum similarity to expected topics",
+    },
+    "zeroshot_min_similarity_help": {
+        "fr": "Similarité sémantique minimale requise pour associer un document à un sujet attendu.",
+        "en": "Minimum semantic similarity required to assign a document to an expected topic.",
+    },
     # Analysis parameters
     "analysis_params_title": {
         "fr": "Paramètres d'analyse de la veille {}: éléments à inclure",

--- a/bertrend/bertrend_apps/prospective_demo/models_info.py
+++ b/bertrend/bertrend_apps/prospective_demo/models_info.py
@@ -161,6 +161,26 @@ def edit_model_parameters(row_dict: dict):
         help=f"{INFO_ICON} {translate('split_by_paragraph_help')}",
     )
 
+    current_model_config = st.session_state.model_analysis_cfg[model_id]["model_config"]
+    zeroshot_topics = st.text_area(
+        label=translate("zeroshot_topics_label"),
+        placeholder=translate("zeroshot_topics_placeholder"),
+        help=f"{INFO_ICON} {translate('zeroshot_topics_help')}",
+        value="\n".join(current_model_config.get("zeroshot_topic_list", [])),
+    )
+    zeroshot_topic_list = [
+        topic.strip() for topic in zeroshot_topics.splitlines() if topic.strip()
+    ]
+    zeroshot_min_similarity = st.slider(
+        translate("zeroshot_min_similarity_label"),
+        min_value=0.0,
+        max_value=1.0,
+        value=float(current_model_config.get("zeroshot_min_similarity", 0.7)),
+        step=0.05,
+        disabled=not zeroshot_topic_list,
+        help=f"{INFO_ICON} {translate('zeroshot_min_similarity_help')}",
+    )
+
     language = st.segmented_control(
         translate("feed_language_label"),
         selection_mode="single",
@@ -256,6 +276,8 @@ def edit_model_parameters(row_dict: dict):
         "window_size": new_window_size,
         "language": "fr" if language == "French" else "en",
         "split_by_paragraph": split_by_paragraph,
+        "zeroshot_topic_list": zeroshot_topic_list,
+        "zeroshot_min_similarity": zeroshot_min_similarity,
     }
     analysis_config = {
         "topic_evolution": topic_evolution,

--- a/bertrend/bertrend_apps/prospective_demo/process_new_data.py
+++ b/bertrend/bertrend_apps/prospective_demo/process_new_data.py
@@ -250,6 +250,8 @@ def train_new_model_for_period(
     granularity = model_config["granularity"]
     language_code = model_config["language"]
     window_size = model_config["window_size"]
+    zeroshot_topic_list = model_config.get("zeroshot_topic_list", [])
+    zeroshot_min_similarity = model_config.get("zeroshot_min_similarity", 0.7)
 
     # Process new data
     bertrend = train_new_data(
@@ -259,6 +261,8 @@ def train_new_model_for_period(
         embedding_service=embedding_service,
         language="French" if language_code == "fr" else "English",
         granularity=granularity,
+        zeroshot_topic_list=zeroshot_topic_list,
+        zeroshot_min_similarity=zeroshot_min_similarity,
     )
 
     if len(bertrend.doc_groups) < 2:
@@ -349,6 +353,8 @@ def regenerate_models(
     granularity = model_config["granularity"]
     language_code = model_config["language"]
     split_by_paragraph = model_config.get("split_by_paragraph", True)
+    zeroshot_topic_list = model_config.get("zeroshot_topic_list", [])
+    zeroshot_min_similarity = model_config.get("zeroshot_min_similarity", 0.7)
 
     # Load model config
     df = load_all_data(model_id=model_id, user=user, language_code=language_code)
@@ -383,7 +389,11 @@ def regenerate_models(
                 {
                     "global": {
                         "language": "French" if language_code == "fr" else "English"
-                    }
+                    },
+                    "bertopic_model": {
+                        "zeroshot_topic_list": zeroshot_topic_list,
+                        "zeroshot_min_similarity": zeroshot_min_similarity,
+                    },
                 }
             )
         )

--- a/bertrend/tests/apps/test_process_new_data.py
+++ b/bertrend/tests/apps/test_process_new_data.py
@@ -380,6 +380,8 @@ class TestTrainNewModelForPeriod:
             "granularity": 7,
             "window_size": 30,
             "language": "en",
+            "zeroshot_topic_list": ["grid flexibility", "hydrogen storage"],
+            "zeroshot_min_similarity": 0.75,
         }
 
         # Mock BERTrend instance
@@ -443,6 +445,12 @@ class TestTrainNewModelForPeriod:
 
         # Verify key function calls
         mock_train_new_data.assert_called_once()
+        train_kwargs = mock_train_new_data.call_args.kwargs
+        assert train_kwargs["zeroshot_topic_list"] == [
+            "grid flexibility",
+            "hydrogen storage",
+        ]
+        assert train_kwargs["zeroshot_min_similarity"] == 0.75
         mock_bertrend.calculate_signal_popularity.assert_called_once()
         mock_bertrend.classify_signals.assert_called_once()
         mock_generate_llm.assert_called()  # Should be called for each non-empty DataFrame

--- a/bertrend/tests/core/test_bertrend.py
+++ b/bertrend/tests/core/test_bertrend.py
@@ -803,6 +803,8 @@ def test_train_new_data():
     mock_bertrend = MagicMock(spec=BERTrend)
     mock_bertrend.doc_groups = {reference_timestamp: ["doc1", "doc2"]}
     mock_bertrend.config = {"granularity": 7}
+    mock_bertrend.topic_model = MagicMock()
+    mock_bertrend.topic_model.config = {"bertopic_model": {}}
 
     # Create mock methods
     mock_train = MagicMock()
@@ -824,6 +826,8 @@ def test_train_new_data():
             embedding_service=mock_embedding_service,
             granularity=7,
             language="English",
+            zeroshot_topic_list=["grid flexibility", "hydrogen storage"],
+            zeroshot_min_similarity=0.75,
         )
 
         # Assert
@@ -831,6 +835,10 @@ def test_train_new_data():
         mock_embedding_service.embed.assert_called_once()
         mock_train.assert_called_once()
         mock_save.assert_called_once_with(models_path=bertrend_models_path)
+        assert mock_bertrend.topic_model.config["bertopic_model"] == {
+            "zeroshot_topic_list": ["grid flexibility", "hydrogen storage"],
+            "zeroshot_min_similarity": 0.75,
+        }
         assert result == mock_bertrend
 
 

--- a/bertrend/tests/core/test_topic_model.py
+++ b/bertrend/tests/core/test_topic_model.py
@@ -3,7 +3,7 @@
 #  SPDX-License-Identifier: MPL-2.0
 #  This file is part of BERTrend.
 import tomllib
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
@@ -260,6 +260,36 @@ def test_create_topic_model_with_empty_zeroshot_topic_list(
     assert (
         result.topic_model.zeroshot_topic_list is None
     )  # Check that it was set to None internally
+
+
+def test_fit_preserves_zeroshot_topic_labels(
+    topic_model, mock_sentence_transformer, mock_embedding
+):
+    """Keep user-provided zero-shot labels after topic representation updates."""
+    mock_bertopic = MagicMock(spec=BERTopic)
+    mock_bertopic.fit_transform.return_value = ([0, 1], [1.0, 1.0])
+    mock_bertopic._outliers = 0
+    mock_bertopic.zeroshot_topic_list = ["solar power"]
+    mock_bertopic.topic_labels_ = {0: "solar power", 1: "1_generated"}
+
+    def replace_labels(*args, **kwargs):
+        mock_bertopic.topic_labels_ = {0: "0_generated", 1: "1_generated"}
+
+    mock_bertopic.update_topics.side_effect = replace_labels
+
+    with patch("bertrend.BERTopicModel.BERTopic", return_value=mock_bertopic):
+        result = topic_model.fit(
+            ["Solar document", "Other document"],
+            embedding_model=mock_sentence_transformer,
+            embeddings=mock_embedding,
+            zeroshot_topic_list=["solar power"],
+            zeroshot_min_similarity=0.7,
+        )
+
+    assert result.topic_model.topic_labels_ == {
+        0: "solar power",
+        1: "1_generated",
+    }
 
 
 def test_create_topic_model_exception_handling(


### PR DESCRIPTION
## Summary

- expose BERTrend's existing zero-shot topic support in the Prospective Demo model editor
- persist expected topics and the similarity threshold per model
- apply those settings during incremental training and full regeneration
- preserve user-defined zero-shot labels after BERTopic representation updates

## Why

The Prospective Demo could not configure BERTrend's existing zero-shot capability, leaving scheduled models limited to fully unsupervised topic discovery.

## Testing

- `BERTREND_BASE_DIR=/tmp/bertrend-pr-create-final .venv/bin/pytest -q bertrend/tests/core bertrend/tests/apps` (`137 passed`)
- Ruff formatting check passed for all changed files
- Ruff lint check passed for all changed files
- Streamlit model-editing flow verified
- real BERTopic smoke test assigned documents to the configured topics

Closes #51
