### PR TITLE
feat: add topic feedback to prospective demo

### DIFF
--- a/bertrend/bertrend_apps/prospective_demo/automated_report_generation.py
+++ b/bertrend/bertrend_apps/prospective_demo/automated_report_generation.py
@@ -31,6 +31,10 @@ from bertrend.bertrend_apps.prospective_demo.report_generation_utils import (
     create_temp_report,
     render_html_report,
 )
+from bertrend.bertrend_apps.prospective_demo.topic_feedback import (
+    apply_topic_feedback,
+    load_topic_feedback,
+)
 from bertrend.bertrend_apps.prospective_demo.utils import is_valid_email
 from bertrend.llm_utils.newsletter_model import (
     STRONG_TOPIC_TYPE,
@@ -103,6 +107,7 @@ def load_signal_data(
         Tuple of (weak_signals_df, strong_signals_df)
     """
     interpretation_path = get_model_interpretation_path(user, model_id, reference_ts)
+    feedback = load_topic_feedback(get_user_models_path(user, model_id))
 
     # Load from parquet files which contain all necessary columns
     # (URLs, LLM Title, LLM Description, Topic, etc.) along with interpretation data
@@ -136,6 +141,7 @@ def load_signal_data(
                 on="Topic",
                 how="left",
             )
+        weak_signals = apply_topic_feedback(weak_signals, feedback)
         logger.info(f"Loaded {len(weak_signals)} weak signals")
         if max_emerging_topics is not None and len(weak_signals) > max_emerging_topics:
             weak_signals = weak_signals.head(max_emerging_topics)
@@ -159,6 +165,7 @@ def load_signal_data(
                 on="Topic",
                 how="left",
             )
+        strong_signals = apply_topic_feedback(strong_signals, feedback)
         logger.info(f"Loaded {len(strong_signals)} strong signals")
         if max_strong_topics is not None and len(strong_signals) > max_strong_topics:
             strong_signals = strong_signals.head(max_strong_topics)

--- a/bertrend/bertrend_apps/prospective_demo/dashboard_analysis.py
+++ b/bertrend/bertrend_apps/prospective_demo/dashboard_analysis.py
@@ -13,15 +13,28 @@ from bertrend.bertrend_apps.prospective_demo import (
     STRONG_SIGNALS,
     WEAK_SIGNALS,
     get_model_interpretation_path,
+    get_user_models_path,
 )
 from bertrend.bertrend_apps.prospective_demo.dashboard_common import (
     choose_id_and_ts,
     get_df_topics,
 )
 from bertrend.bertrend_apps.prospective_demo.i18n import translate
+from bertrend.bertrend_apps.prospective_demo.topic_feedback import (
+    HIDDEN_TOPIC,
+    PROMOTED_TOPIC,
+    TopicFeedback,
+    get_topic_feedback_icon,
+    load_topic_feedback,
+    order_topic_ids,
+    set_topic_feedback,
+)
 from bertrend.demos.demos_utils.icons import ERROR_ICON
 from bertrend.trend_analysis.data_structure import SignalAnalysis, TopicSummaryList
 from bertrend.trend_analysis.prompts import fill_html_template
+
+NO_TOPIC_FEEDBACK = "none"
+TOPIC_FEEDBACK_SAVED_MESSAGE_KEY = "_topic_feedback_saved"
 
 
 @st.fragment()
@@ -39,17 +52,27 @@ def dashboard_analysis():
         model_id=model_id,
         reference_ts=reference_ts,
     )
+    model_path = get_user_models_path(st.session_state.username, model_id)
 
     # Detailed analysis
     st.subheader(translate("detailed_analysis_by_topic"))
+    if st.session_state.pop(TOPIC_FEEDBACK_SAVED_MESSAGE_KEY, False):
+        st.success(translate("topic_feedback_saved"))
     dfs_topics = get_df_topics(model_interpretation_path)
-    display_detailed_analysis(model_id, model_interpretation_path, dfs_topics)
+    display_detailed_analysis(
+        model_id, model_interpretation_path, model_path, dfs_topics
+    )
 
 
 @st.fragment()
 def display_detailed_analysis(
-    model_id: str, model_interpretation_path: Path, dfs_topics: dict[str, pd.DataFrame]
+    model_id: str,
+    model_interpretation_path: Path,
+    model_path: Path,
+    dfs_topics: dict[str, pd.DataFrame],
 ):
+    feedback = load_topic_feedback(model_path)
+
     # Retrieve previously computed interpretation
     interpretations = {}
     for df_id, df in dfs_topics.items():
@@ -78,14 +101,20 @@ def display_detailed_analysis(
         signal_topics[WEAK_SIGNALS] = list(interpretations[WEAK_SIGNALS]["topic"])
     if STRONG_SIGNALS in interpretations:
         signal_topics[STRONG_SIGNALS] = list(interpretations[STRONG_SIGNALS]["topic"])
-    signal_list = signal_topics[WEAK_SIGNALS] + signal_topics[STRONG_SIGNALS]
+    signal_list = order_topic_ids(
+        signal_topics[WEAK_SIGNALS] + signal_topics[STRONG_SIGNALS],
+        feedback,
+        include_hidden=True,
+    )
     selected_signal = st.selectbox(
         label=translate("topic_selection"),
         label_visibility="hidden",
         options=signal_list,
-        format_func=lambda signal_id: (
-            f"{'📈 [' + translate('emerging_topic') if signal_id in signal_topics[WEAK_SIGNALS] else '🌟 [' + translate('strong_topic')} "
-            f"{signal_id}] {get_row(signal_id, interpretations[WEAK_SIGNALS] if signal_id in signal_topics[WEAK_SIGNALS] else interpretations[STRONG_SIGNALS])[LLM_TOPIC_TITLE_COLUMN]}"
+        format_func=lambda signal_id: _format_signal_label(
+            signal_id,
+            signal_topics,
+            interpretations,
+            feedback,
         ),
     )
     # Summary of the topic
@@ -110,6 +139,12 @@ def display_detailed_analysis(
         color = "green"
     st.subheader(f":{color}[**{desc[LLM_TOPIC_TITLE_COLUMN]}**]")
     st.write(desc[LLM_TOPIC_DESCRIPTION_COLUMN])
+    _display_topic_feedback_control(
+        model_id,
+        model_path,
+        selected_signal,
+        feedback,
+    )
 
     # Detailed description (HTML formatted)
     # Handle nan values for summary and analysis
@@ -128,6 +163,50 @@ def display_detailed_analysis(
         st.warning(translate("no_analysis_available"))
 
     st.session_state.signal_interpretations[model_id] = interpretations
+
+
+def _format_signal_label(
+    signal_id: int,
+    signal_topics: dict[str, list[int]],
+    interpretations: dict[str, pd.DataFrame],
+    feedback: dict[int, TopicFeedback],
+) -> str:
+    is_weak_signal = signal_id in signal_topics[WEAK_SIGNALS]
+    category = WEAK_SIGNALS if is_weak_signal else STRONG_SIGNALS
+    category_icon = "📈" if is_weak_signal else "🌟"
+    category_label = translate("emerging_topic" if is_weak_signal else "strong_topic")
+    row = get_row(signal_id, interpretations.get(category))
+    title = (
+        row[LLM_TOPIC_TITLE_COLUMN] if row is not None else translate("untitled_topic")
+    )
+    feedback_icon = get_topic_feedback_icon(signal_id, feedback)
+    prefix = f"{feedback_icon} " if feedback_icon else ""
+    return f"{prefix}{category_icon} [{category_label} {signal_id}] {title}"
+
+
+def _display_topic_feedback_control(
+    model_id: str,
+    model_path: Path,
+    topic_id: int,
+    feedback: dict[int, TopicFeedback],
+) -> None:
+    current_feedback = feedback.get(int(topic_id))
+    selected_feedback = st.segmented_control(
+        translate("topic_feedback"),
+        options=[NO_TOPIC_FEEDBACK, PROMOTED_TOPIC, HIDDEN_TOPIC],
+        default=current_feedback or NO_TOPIC_FEEDBACK,
+        format_func=lambda status: translate(f"topic_feedback_{status}"),
+        help=translate("topic_feedback_help"),
+        selection_mode="single",
+        key=f"topic_feedback_{model_id}_{topic_id}",
+    )
+    new_feedback = (
+        None if selected_feedback in {None, NO_TOPIC_FEEDBACK} else selected_feedback
+    )
+    if new_feedback != current_feedback:
+        set_topic_feedback(model_path, topic_id, new_feedback)
+        st.session_state[TOPIC_FEEDBACK_SAVED_MESSAGE_KEY] = True
+        st.rerun(scope="app")
 
 
 def get_row(signal_id: int, df: pd.DataFrame) -> str | None:

--- a/bertrend/bertrend_apps/prospective_demo/dashboard_signals.py
+++ b/bertrend/bertrend_apps/prospective_demo/dashboard_signals.py
@@ -90,18 +90,22 @@ def signal_analysis():
     feedback = load_topic_feedback(
         get_user_models_path(st.session_state.username, model_id)
     )
+    raw_topics = get_df_topics(model_interpretation_path)
+    # Feedback applied once for source exploration (selectbox options / ordering).
+    # Table display applies it separately after a popularity sort in
+    # _prepare_topics_for_display — pass raw frames there to avoid a redundant pass.
     dfs_topics = {
         category: apply_topic_feedback(topics, feedback)
-        for category, topics in get_df_topics(model_interpretation_path).items()
+        for category, topics in raw_topics.items()
     }
 
     col1, col2 = st.columns(COLS_RATIO)
     with col1:
         # Display dataframes for weak_signals, strong, etc
         display_translated_signal_categories(
-            dfs_topics[NOISE],
-            dfs_topics[WEAK_SIGNALS],
-            dfs_topics[STRONG_SIGNALS],
+            raw_topics[NOISE],
+            raw_topics[WEAK_SIGNALS],
+            raw_topics[STRONG_SIGNALS],
             reference_ts,
             columns=columns,
             column_config=column_config,
@@ -257,7 +261,12 @@ def _prepare_topics_for_display(
     columns: list[str],
     feedback: dict[int, TopicFeedback],
 ) -> pd.DataFrame:
-    """Prepare a signal table while keeping promoted topics visible first."""
+    """Prepare a signal table while keeping promoted topics visible first.
+
+    Callers should pass raw (unfiltered) topic frames. Popularity is sorted first,
+    then apply_topic_feedback re-orders so promoted topics still float to the top
+    while relative popularity order is preserved within each feedback group.
+    """
     displayed_topics = topics[columns].sort_values(
         by=["Latest_Popularity"], ascending=False
     )

--- a/bertrend/bertrend_apps/prospective_demo/dashboard_signals.py
+++ b/bertrend/bertrend_apps/prospective_demo/dashboard_signals.py
@@ -13,12 +13,21 @@ from bertrend.bertrend_apps.prospective_demo import (
     URLS_COLUMN,
     WEAK_SIGNALS,
     get_model_interpretation_path,
+    get_user_models_path,
 )
 from bertrend.bertrend_apps.prospective_demo.dashboard_common import (
     choose_id_and_ts,
     get_df_topics,
 )
 from bertrend.bertrend_apps.prospective_demo.i18n import translate
+from bertrend.bertrend_apps.prospective_demo.topic_feedback import (
+    PROMOTED_TOPIC,
+    TopicFeedback,
+    apply_topic_feedback,
+    get_topic_feedback_icon,
+    load_topic_feedback,
+    order_topic_ids,
+)
 from bertrend.demos.demos_utils.icons import (
     NOISE_ICON,
     STRONG_SIGNAL_ICON,
@@ -78,7 +87,13 @@ def signal_analysis():
         URLS_COLUMN: st.column_config.LinkColumn(),
     }
 
-    dfs_topics = get_df_topics(model_interpretation_path)
+    feedback = load_topic_feedback(
+        get_user_models_path(st.session_state.username, model_id)
+    )
+    dfs_topics = {
+        category: apply_topic_feedback(topics, feedback)
+        for category, topics in get_df_topics(model_interpretation_path).items()
+    }
 
     col1, col2 = st.columns(COLS_RATIO)
     with col1:
@@ -90,14 +105,17 @@ def signal_analysis():
             reference_ts,
             columns=columns,
             column_config=column_config,
+            feedback=feedback,
         )
 
     with col2:
-        explore_topic_sources(dfs_topics)
+        explore_topic_sources(dfs_topics, feedback)
 
 
 @st.fragment
-def explore_topic_sources(dfs_topics):
+def explore_topic_sources(
+    dfs_topics: dict[str, pd.DataFrame], feedback: dict[int, TopicFeedback]
+):
     st.write(f"**{translate('explore_sources_by_topic')}**")
     selected_signal_type = st.pills(
         translate("signal_type"),
@@ -114,20 +132,17 @@ def explore_topic_sources(dfs_topics):
         st.warning(f"{WARNING_ICON} {translate('no_data')}")
     else:
         selected_df = selected_df.sort_values(by=["Latest_Popularity"], ascending=False)
-        options = selected_df["Topic"].tolist()
+        options = order_topic_ids(selected_df["Topic"].tolist(), feedback)
         topic_id = st.selectbox(
             index=None,
             label=translate("topic_selection"),
             label_visibility="hidden",
             options=options,
-            format_func=lambda x: (
-                f"{'📈 [' + translate('emerging_topic') if selected_signal_type == translate('emerging_topics') else '🌟 [' + translate('strong_topic')} {x}] "
-                + (
-                    selected_df[selected_df["Topic"] == x][
-                        LLM_TOPIC_TITLE_COLUMN
-                    ].values[0]
-                    or translate("untitled_topic")
-                )
+            format_func=lambda topic: _format_source_topic_label(
+                topic,
+                selected_signal_type,
+                selected_df,
+                feedback,
             ),
         )
         if topic_id is None:
@@ -144,6 +159,25 @@ def explore_topic_sources(dfs_topics):
         )
 
 
+def _format_source_topic_label(
+    topic_id: int,
+    selected_signal_type: str,
+    selected_df: pd.DataFrame,
+    feedback: dict[int, TopicFeedback],
+) -> str:
+    is_emerging = selected_signal_type == translate("emerging_topics")
+    category_icon = "📈" if is_emerging else "🌟"
+    category_label = translate("emerging_topic" if is_emerging else "strong_topic")
+    title = selected_df.loc[
+        selected_df["Topic"] == topic_id, LLM_TOPIC_TITLE_COLUMN
+    ].iloc[0]
+    if pd.isna(title) or not title:
+        title = translate("untitled_topic")
+    feedback_icon = get_topic_feedback_icon(topic_id, feedback)
+    prefix = f"{feedback_icon} " if feedback_icon else ""
+    return f"{prefix}{category_icon} [{category_label} {topic_id}] {title}"
+
+
 def display_translated_signal_categories(
     noise_topics_df: pd.DataFrame,
     weak_signal_topics_df: pd.DataFrame,
@@ -152,18 +186,19 @@ def display_translated_signal_categories(
     columns=None,
     column_order=None,
     column_config=None,
+    feedback: dict[int, TopicFeedback] | None = None,
 ):
     """Wrapper around display_signal_categories_df that uses translated text."""
+    feedback = feedback or {}
     # Weak Signals
     with st.expander(
         f":orange[{WEAK_SIGNAL_ICON} {translate('weak_signals')}]", expanded=True
     ):
         st.subheader(f":orange[{translate('weak_signals')}]")
         if not weak_signal_topics_df.empty:
-            displayed_df = weak_signal_topics_df[columns].sort_values(
-                by=["Latest_Popularity"], ascending=False
+            displayed_df = _prepare_topics_for_display(
+                weak_signal_topics_df, columns, feedback
             )
-            displayed_df["Documents"] = displayed_df["Documents"].astype(str)
             st.dataframe(
                 displayed_df,
                 column_order=column_order if column_order else columns,
@@ -182,10 +217,9 @@ def display_translated_signal_categories(
     ):
         st.subheader(f":green[{translate('strong_signals')}]")
         if not strong_signal_topics_df.empty:
-            displayed_df = strong_signal_topics_df[columns].sort_values(
-                by=["Latest_Popularity"], ascending=False
+            displayed_df = _prepare_topics_for_display(
+                strong_signal_topics_df, columns, feedback
             )
-            displayed_df["Documents"] = displayed_df["Documents"].astype(str)
             st.dataframe(
                 displayed_df,
                 column_order=column_order if column_order else columns,
@@ -202,10 +236,9 @@ def display_translated_signal_categories(
     with st.expander(f":grey[{NOISE_ICON} {translate('noise')}]", expanded=True):
         st.subheader(f":grey[{translate('noise')}]")
         if not noise_topics_df.empty:
-            displayed_df = noise_topics_df[columns].sort_values(
-                by=["Latest_Popularity"], ascending=False
+            displayed_df = _prepare_topics_for_display(
+                noise_topics_df, columns, feedback
             )
-            displayed_df["Documents"] = displayed_df["Documents"].astype(str)
             st.dataframe(
                 displayed_df,
                 column_order=column_order if column_order else columns,
@@ -217,6 +250,30 @@ def display_translated_signal_categories(
                 translate("no_noise_signals").format(timestamp=window_end),
                 icon=WARNING_ICON,
             )
+
+
+def _prepare_topics_for_display(
+    topics: pd.DataFrame,
+    columns: list[str],
+    feedback: dict[int, TopicFeedback],
+) -> pd.DataFrame:
+    """Prepare a signal table while keeping promoted topics visible first."""
+    displayed_topics = topics[columns].sort_values(
+        by=["Latest_Popularity"], ascending=False
+    )
+    displayed_topics = apply_topic_feedback(displayed_topics, feedback)
+    promoted_topic_ids = {
+        topic_id for topic_id, status in feedback.items() if status == PROMOTED_TOPIC
+    }
+    promoted = displayed_topics["Topic"].isin(promoted_topic_ids)
+    displayed_topics.loc[promoted, LLM_TOPIC_TITLE_COLUMN] = (
+        "⭐ "
+        + displayed_topics.loc[promoted, LLM_TOPIC_TITLE_COLUMN]
+        .fillna(translate("untitled_topic"))
+        .astype(str)
+    )
+    displayed_topics["Documents"] = displayed_topics["Documents"].astype(str)
+    return displayed_topics
 
 
 @st.dialog(translate("explore_sources"), width="large")

--- a/bertrend/bertrend_apps/prospective_demo/i18n_translations.py
+++ b/bertrend/bertrend_apps/prospective_demo/i18n_translations.py
@@ -58,6 +58,30 @@ TRANSLATIONS = {
         "fr": "Sélection de la date d'analyse parmi celles disponibles",
         "en": "Selection of the analysis date from those available",
     },
+    "topic_feedback": {
+        "fr": "Préférence pour ce sujet",
+        "en": "Topic preference",
+    },
+    "topic_feedback_help": {
+        "fr": "Cette préférence s'applique à cette veille. Elle modifie l'affichage et la sélection des rapports, sans réentraîner le modèle.",
+        "en": "This preference applies to this monitoring model. It changes dashboard and report selection without retraining the model.",
+    },
+    "topic_feedback_none": {
+        "fr": "Aucune",
+        "en": "None",
+    },
+    "topic_feedback_promoted": {
+        "fr": "⭐ Prioriser",
+        "en": "⭐ Prioritize",
+    },
+    "topic_feedback_hidden": {
+        "fr": "🚫 Masquer",
+        "en": "🚫 Hide",
+    },
+    "topic_feedback_saved": {
+        "fr": "Préférence enregistrée.",
+        "en": "Preference saved.",
+    },
     # dashboard_comparative.py translations
     "comparative_analysis_title": {
         "fr": "Analyse Comparative entre Périodes",

--- a/bertrend/bertrend_apps/prospective_demo/report_generation.py
+++ b/bertrend/bertrend_apps/prospective_demo/report_generation.py
@@ -16,6 +16,7 @@ from bertrend.bertrend_apps.prospective_demo import (
     STRONG_SIGNALS,
     URLS_COLUMN,
     WEAK_SIGNALS,
+    get_user_models_path,
 )
 from bertrend.bertrend_apps.prospective_demo.dashboard_common import choose_id_and_ts
 from bertrend.bertrend_apps.prospective_demo.data_model import (
@@ -27,6 +28,12 @@ from bertrend.bertrend_apps.prospective_demo.report_generation_utils import (
     MAXIMUM_NUMBER_OF_ARTICLES,
     create_temp_report,
     render_html_report,
+)
+from bertrend.bertrend_apps.prospective_demo.topic_feedback import (
+    PROMOTED_TOPIC,
+    TopicFeedback,
+    apply_topic_feedback,
+    load_topic_feedback,
 )
 from bertrend.bertrend_apps.prospective_demo.utils import is_valid_email
 from bertrend.demos.demos_utils.icons import (
@@ -60,6 +67,9 @@ def choose_topics():
     if model_id not in dfs_interpretation:
         st.error(f"{ERROR_ICON} {translate('no_data')}")
         st.stop()
+    feedback = load_topic_feedback(
+        get_user_models_path(st.session_state.username, model_id)
+    )
     cols = st.columns(2)
     with cols[0]:
         st.write(f"#### :orange[{translate('emerging_topics')}]")
@@ -68,8 +78,10 @@ def choose_topics():
             filtered_weak_signals = None
         else:
             df_w = dfs_interpretation[model_id][WEAK_SIGNALS]
-            weak_topics_list = choose_from_df(df_w)
-            filtered_weak_signals = df_w[df_w["Topic"].isin(weak_topics_list)]
+            weak_topics_list = choose_from_df(df_w, feedback)
+            filtered_weak_signals = apply_topic_feedback(
+                df_w[df_w["Topic"].isin(weak_topics_list)], feedback
+            )
 
     with cols[1]:
         st.write(f"#### :green[{translate('strong_topics')}]")
@@ -78,18 +90,29 @@ def choose_topics():
             filtered_strong_signals = None
         else:
             df_w = dfs_interpretation[model_id][STRONG_SIGNALS]
-            strong_topics_list = choose_from_df(df_w)
-            filtered_strong_signals = df_w[df_w["Topic"].isin(strong_topics_list)]
+            strong_topics_list = choose_from_df(df_w, feedback)
+            filtered_strong_signals = apply_topic_feedback(
+                df_w[df_w["Topic"].isin(strong_topics_list)], feedback
+            )
 
     return filtered_weak_signals, filtered_strong_signals
 
 
-def choose_from_df(df: pd.DataFrame):
-    df["A retenir"] = True
-    df["Sujet"] = df[LLM_TOPIC_TITLE_COLUMN]
-    df["Description"] = df[LLM_TOPIC_DESCRIPTION_COLUMN]
+def choose_from_df(df: pd.DataFrame, feedback: dict[int, TopicFeedback]):
+    displayed_topics = apply_topic_feedback(df, feedback)
+    displayed_topics["A retenir"] = True
+    displayed_topics["Sujet"] = displayed_topics[LLM_TOPIC_TITLE_COLUMN]
+    promoted = displayed_topics["Topic"].isin(
+        {topic_id for topic_id, status in feedback.items() if status == PROMOTED_TOPIC}
+    )
+    displayed_topics.loc[promoted, "Sujet"] = "⭐ " + displayed_topics.loc[
+        promoted, "Sujet"
+    ].fillna(translate("untitled_topic")).astype(str)
+    displayed_topics["Description"] = displayed_topics[LLM_TOPIC_DESCRIPTION_COLUMN]
     columns = ["Topic", "A retenir", "Sujet", "Description"]
-    edited_df = st.data_editor(df[columns], num_rows="dynamic", column_order=columns)
+    edited_df = st.data_editor(
+        displayed_topics[columns], num_rows="dynamic", column_order=columns
+    )
     selection = edited_df[edited_df["A retenir"]]["Topic"].tolist()
     return selection
 

--- a/bertrend/bertrend_apps/prospective_demo/topic_feedback.py
+++ b/bertrend/bertrend_apps/prospective_demo/topic_feedback.py
@@ -14,6 +14,8 @@ PROMOTED_TOPIC = "promoted"
 HIDDEN_TOPIC = "hidden"
 TOPIC_FEEDBACK_FILE = "topic_feedback.json"
 
+# Literal values must stay in sync with PROMOTED_TOPIC / HIDDEN_TOPIC above
+# (typing.Literal cannot reference those constants).
 TopicFeedback = Literal["promoted", "hidden"]
 VALID_TOPIC_FEEDBACK = {PROMOTED_TOPIC, HIDDEN_TOPIC}
 

--- a/bertrend/bertrend_apps/prospective_demo/topic_feedback.py
+++ b/bertrend/bertrend_apps/prospective_demo/topic_feedback.py
@@ -1,0 +1,144 @@
+#  Copyright (c) 2024-2026, RTE (https://www.rte-france.com)
+#  See AUTHORS.txt
+#  SPDX-License-Identifier: MPL-2.0
+#  This file is part of BERTrend.
+
+import json
+from pathlib import Path
+from typing import Literal
+
+import pandas as pd
+from loguru import logger
+
+PROMOTED_TOPIC = "promoted"
+HIDDEN_TOPIC = "hidden"
+TOPIC_FEEDBACK_FILE = "topic_feedback.json"
+
+TopicFeedback = Literal["promoted", "hidden"]
+VALID_TOPIC_FEEDBACK = {PROMOTED_TOPIC, HIDDEN_TOPIC}
+
+
+def load_topic_feedback(model_path: Path) -> dict[int, TopicFeedback]:
+    """Load the user's topic feedback for one monitored model."""
+    feedback_path = model_path / TOPIC_FEEDBACK_FILE
+    if not feedback_path.exists():
+        return {}
+
+    try:
+        raw_feedback = json.loads(feedback_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning(f"Unable to load topic feedback from {feedback_path}: {exc}")
+        return {}
+
+    if not isinstance(raw_feedback, dict):
+        logger.warning(f"Ignoring invalid topic feedback in {feedback_path}")
+        return {}
+
+    feedback = {}
+    for topic_id, status in raw_feedback.items():
+        try:
+            normalized_topic_id = int(topic_id)
+        except (TypeError, ValueError):
+            continue
+        if status in VALID_TOPIC_FEEDBACK:
+            feedback[normalized_topic_id] = status
+    return feedback
+
+
+def save_topic_feedback(model_path: Path, feedback: dict[int, TopicFeedback]) -> None:
+    """Save the user's topic feedback for one monitored model."""
+    model_path.mkdir(parents=True, exist_ok=True)
+    normalized_feedback = {
+        str(int(topic_id)): status
+        for topic_id, status in sorted(feedback.items())
+        if status in VALID_TOPIC_FEEDBACK
+    }
+    feedback_path = model_path / TOPIC_FEEDBACK_FILE
+    feedback_path.write_text(
+        json.dumps(normalized_feedback, indent=2) + "\n", encoding="utf-8"
+    )
+
+
+def set_topic_feedback(
+    model_path: Path,
+    topic_id: int,
+    status: TopicFeedback | None,
+) -> dict[int, TopicFeedback]:
+    """Set or clear feedback for one topic and return the updated mapping."""
+    if status is not None and status not in VALID_TOPIC_FEEDBACK:
+        raise ValueError(f"Unsupported topic feedback: {status}")
+
+    feedback = load_topic_feedback(model_path)
+    normalized_topic_id = int(topic_id)
+    if status is None:
+        feedback.pop(normalized_topic_id, None)
+    else:
+        feedback[normalized_topic_id] = status
+    save_topic_feedback(model_path, feedback)
+    return feedback
+
+
+def _feedback_rank(topic_id: int, feedback: dict[int, TopicFeedback]) -> int:
+    status = feedback.get(int(topic_id))
+    if status == PROMOTED_TOPIC:
+        return 0
+    if status == HIDDEN_TOPIC:
+        return 2
+    return 1
+
+
+def get_topic_feedback_icon(topic_id: int, feedback: dict[int, TopicFeedback]) -> str:
+    """Return the compact icon used to expose topic feedback in the UI."""
+    status = feedback.get(int(topic_id))
+    if status == PROMOTED_TOPIC:
+        return "⭐"
+    if status == HIDDEN_TOPIC:
+        return "🚫"
+    return ""
+
+
+def order_topic_ids(
+    topic_ids: list[int],
+    feedback: dict[int, TopicFeedback],
+    *,
+    include_hidden: bool = False,
+) -> list[int]:
+    """Order promoted topics first and hidden topics last or omit them."""
+    visible_topic_ids = [
+        topic_id
+        for topic_id in topic_ids
+        if include_hidden or feedback.get(int(topic_id)) != HIDDEN_TOPIC
+    ]
+    return sorted(
+        visible_topic_ids,
+        key=lambda topic_id: _feedback_rank(topic_id, feedback),
+    )
+
+
+def apply_topic_feedback(
+    topics: pd.DataFrame,
+    feedback: dict[int, TopicFeedback],
+    *,
+    include_hidden: bool = False,
+    topic_column: str = "Topic",
+) -> pd.DataFrame:
+    """Return a copy filtered and ordered according to saved topic feedback."""
+    if topics.empty:
+        return topics.copy()
+    if topic_column not in topics:
+        raise KeyError(f"Missing topic column: {topic_column}")
+
+    result = topics.copy()
+    if not include_hidden:
+        hidden_topic_ids = {
+            topic_id for topic_id, status in feedback.items() if status == HIDDEN_TOPIC
+        }
+        result = result[~result[topic_column].isin(hidden_topic_ids)]
+
+    ordered_positions = sorted(
+        range(len(result)),
+        key=lambda position: _feedback_rank(
+            result.iloc[position][topic_column], feedback
+        ),
+    )
+    return result.iloc[ordered_positions].copy()

--- a/bertrend/tests/apps/test_topic_feedback.py
+++ b/bertrend/tests/apps/test_topic_feedback.py
@@ -1,0 +1,94 @@
+#  Copyright (c) 2024-2026, RTE (https://www.rte-france.com)
+#  See AUTHORS.txt
+#  SPDX-License-Identifier: MPL-2.0
+#  This file is part of BERTrend.
+
+import json
+
+import pandas as pd
+import pytest
+
+from bertrend.bertrend_apps.prospective_demo.topic_feedback import (
+    HIDDEN_TOPIC,
+    PROMOTED_TOPIC,
+    apply_topic_feedback,
+    get_topic_feedback_icon,
+    load_topic_feedback,
+    order_topic_ids,
+    set_topic_feedback,
+)
+
+
+def test_topic_feedback_round_trip_and_clear(tmp_path):
+    assert load_topic_feedback(tmp_path) == {}
+
+    set_topic_feedback(tmp_path, 12, PROMOTED_TOPIC)
+    set_topic_feedback(tmp_path, 7, HIDDEN_TOPIC)
+
+    assert load_topic_feedback(tmp_path) == {
+        7: HIDDEN_TOPIC,
+        12: PROMOTED_TOPIC,
+    }
+
+    set_topic_feedback(tmp_path, 12, None)
+
+    assert load_topic_feedback(tmp_path) == {7: HIDDEN_TOPIC}
+
+
+def test_topic_feedback_is_saved_as_simple_json(tmp_path):
+    set_topic_feedback(tmp_path, 3, PROMOTED_TOPIC)
+
+    contents = json.loads((tmp_path / "topic_feedback.json").read_text())
+
+    assert contents == {"3": PROMOTED_TOPIC}
+
+
+def test_invalid_topic_feedback_is_rejected(tmp_path):
+    with pytest.raises(ValueError, match="Unsupported topic feedback"):
+        set_topic_feedback(tmp_path, 1, "maybe")
+
+
+def test_malformed_topic_feedback_does_not_break_the_dashboard(tmp_path):
+    (tmp_path / "topic_feedback.json").write_text("not json")
+
+    assert load_topic_feedback(tmp_path) == {}
+
+
+def test_apply_topic_feedback_hides_and_prioritizes_without_mutating_input():
+    topics = pd.DataFrame(
+        {
+            "Topic": [1, 2, 3, 4],
+            "LLM Title": ["One", "Two", "Three", "Four"],
+        }
+    )
+    feedback = {2: HIDDEN_TOPIC, 3: PROMOTED_TOPIC, 4: PROMOTED_TOPIC}
+
+    visible_topics = apply_topic_feedback(topics, feedback)
+
+    assert visible_topics["Topic"].tolist() == [3, 4, 1]
+    assert topics["Topic"].tolist() == [1, 2, 3, 4]
+    assert visible_topics.columns.tolist() == topics.columns.tolist()
+
+
+def test_apply_topic_feedback_can_keep_hidden_topics_for_management():
+    topics = pd.DataFrame({"Topic": [1, 2, 3]})
+    feedback = {1: HIDDEN_TOPIC, 2: PROMOTED_TOPIC}
+
+    all_topics = apply_topic_feedback(topics, feedback, include_hidden=True)
+
+    assert all_topics["Topic"].tolist() == [2, 3, 1]
+
+
+def test_order_topic_ids_matches_dataframe_feedback_ordering():
+    feedback = {2: HIDDEN_TOPIC, 3: PROMOTED_TOPIC}
+
+    assert order_topic_ids([1, 2, 3, 4], feedback) == [3, 1, 4]
+    assert order_topic_ids([1, 2, 3, 4], feedback, include_hidden=True) == [3, 1, 4, 2]
+
+
+def test_topic_feedback_icons_make_saved_preferences_visible():
+    feedback = {2: HIDDEN_TOPIC, 3: PROMOTED_TOPIC}
+
+    assert get_topic_feedback_icon(1, feedback) == ""
+    assert get_topic_feedback_icon(2, feedback) == "🚫"
+    assert get_topic_feedback_icon(3, feedback) == "⭐"

--- a/bertrend/tests/apps/test_topic_feedback_ui.py
+++ b/bertrend/tests/apps/test_topic_feedback_ui.py
@@ -1,0 +1,159 @@
+#  Copyright (c) 2024-2026, RTE (https://www.rte-france.com)
+#  See AUTHORS.txt
+#  SPDX-License-Identifier: MPL-2.0
+#  This file is part of BERTrend.
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+
+from bertrend.bertrend_apps.prospective_demo import (
+    LLM_TOPIC_DESCRIPTION_COLUMN,
+    LLM_TOPIC_TITLE_COLUMN,
+)
+from bertrend.bertrend_apps.prospective_demo import dashboard_analysis
+from bertrend.bertrend_apps.prospective_demo import automated_report_generation
+from bertrend.bertrend_apps.prospective_demo import report_generation
+from bertrend.bertrend_apps.prospective_demo.dashboard_signals import (
+    _prepare_topics_for_display,
+)
+from bertrend.bertrend_apps.prospective_demo.topic_feedback import (
+    HIDDEN_TOPIC,
+    PROMOTED_TOPIC,
+    set_topic_feedback,
+)
+
+
+def test_signal_table_hides_and_marks_saved_topic_feedback():
+    topics = pd.DataFrame(
+        {
+            "Topic": [1, 2, 3],
+            LLM_TOPIC_TITLE_COLUMN: ["Most popular", "Hidden", "Preferred"],
+            "Latest_Popularity": [100, 50, 10],
+            "Documents": [["one"], ["two"], ["three"]],
+        }
+    )
+    columns = ["Topic", LLM_TOPIC_TITLE_COLUMN, "Latest_Popularity", "Documents"]
+
+    displayed = _prepare_topics_for_display(
+        topics,
+        columns,
+        {2: HIDDEN_TOPIC, 3: PROMOTED_TOPIC},
+    )
+
+    assert displayed["Topic"].tolist() == [3, 1]
+    assert displayed[LLM_TOPIC_TITLE_COLUMN].tolist() == [
+        "⭐ Preferred",
+        "Most popular",
+    ]
+
+
+def test_report_picker_omits_hidden_topics_and_prioritizes_promoted_topics():
+    topics = pd.DataFrame(
+        {
+            "Topic": [1, 2, 3],
+            LLM_TOPIC_TITLE_COLUMN: ["Normal", "Hidden", "Preferred"],
+            LLM_TOPIC_DESCRIPTION_COLUMN: ["One", "Two", "Three"],
+        }
+    )
+    displayed = {}
+
+    def capture_data_editor(dataframe, **_kwargs):
+        displayed["topics"] = dataframe.copy()
+        return dataframe
+
+    with patch.object(
+        report_generation.st, "data_editor", side_effect=capture_data_editor
+    ):
+        selected = report_generation.choose_from_df(
+            topics,
+            {2: HIDDEN_TOPIC, 3: PROMOTED_TOPIC},
+        )
+
+    assert selected == [3, 1]
+    assert displayed["topics"]["Topic"].tolist() == [3, 1]
+    assert displayed["topics"]["Sujet"].tolist() == ["⭐ Preferred", "Normal"]
+
+
+def test_automated_report_respects_feedback_before_topic_limits(tmp_path):
+    model_path = tmp_path / "model"
+    interpretation_path = tmp_path / "interpretation"
+    interpretation_path.mkdir()
+    pd.DataFrame({"Topic": [1, 2, 3]}).to_parquet(
+        interpretation_path / "weak_signals.parquet"
+    )
+    set_topic_feedback(model_path, 2, HIDDEN_TOPIC)
+    set_topic_feedback(model_path, 3, PROMOTED_TOPIC)
+
+    with (
+        patch.object(
+            automated_report_generation,
+            "get_model_interpretation_path",
+            return_value=interpretation_path,
+        ),
+        patch.object(
+            automated_report_generation,
+            "get_user_models_path",
+            return_value=model_path,
+        ),
+    ):
+        weak_signals, strong_signals = automated_report_generation.load_signal_data(
+            "user",
+            "monitoring-feed",
+            pd.Timestamp("2026-07-31"),
+            max_emerging_topics=2,
+        )
+
+    assert weak_signals["Topic"].tolist() == [3, 1]
+    assert strong_signals is None
+
+
+def test_feedback_control_saves_a_changed_preference():
+    interpretation_path = Path("/tmp/analysis/2026-07-31")
+
+    with (
+        patch.object(
+            dashboard_analysis.st,
+            "segmented_control",
+            return_value=HIDDEN_TOPIC,
+        ),
+        patch.object(dashboard_analysis.st, "session_state", {}),
+        patch.object(dashboard_analysis.st, "rerun") as rerun,
+        patch.object(dashboard_analysis, "translate", side_effect=lambda key: key),
+        patch.object(dashboard_analysis, "set_topic_feedback") as save_feedback,
+    ):
+        dashboard_analysis._display_topic_feedback_control(
+            "monitoring-feed",
+            interpretation_path,
+            7,
+            {},
+        )
+
+    save_feedback.assert_called_once_with(interpretation_path, 7, HIDDEN_TOPIC)
+    rerun.assert_called_once_with(scope="app")
+
+
+def test_feedback_control_clears_an_existing_preference():
+    interpretation_path = Path("/tmp/analysis/2026-07-31")
+
+    with (
+        patch.object(
+            dashboard_analysis.st,
+            "segmented_control",
+            return_value=dashboard_analysis.NO_TOPIC_FEEDBACK,
+        ),
+        patch.object(dashboard_analysis.st, "session_state", {}),
+        patch.object(dashboard_analysis.st, "rerun") as rerun,
+        patch.object(dashboard_analysis, "translate", side_effect=lambda key: key),
+        patch.object(dashboard_analysis, "set_topic_feedback") as save_feedback,
+    ):
+        dashboard_analysis._display_topic_feedback_control(
+            "monitoring-feed",
+            interpretation_path,
+            7,
+            {7: HIDDEN_TOPIC},
+        )
+
+    save_feedback.assert_called_once_with(interpretation_path, 7, None)
+    rerun.assert_called_once_with(scope="app")

--- a/bertrend/tests/apps/test_topic_feedback_ui.py
+++ b/bertrend/tests/apps/test_topic_feedback_ui.py
@@ -15,12 +15,14 @@ from bertrend.bertrend_apps.prospective_demo import (
 from bertrend.bertrend_apps.prospective_demo import dashboard_analysis
 from bertrend.bertrend_apps.prospective_demo import automated_report_generation
 from bertrend.bertrend_apps.prospective_demo import report_generation
+from bertrend.bertrend_apps.prospective_demo import dashboard_signals
 from bertrend.bertrend_apps.prospective_demo.dashboard_signals import (
     _prepare_topics_for_display,
 )
 from bertrend.bertrend_apps.prospective_demo.topic_feedback import (
     HIDDEN_TOPIC,
     PROMOTED_TOPIC,
+    apply_topic_feedback,
     set_topic_feedback,
 )
 
@@ -47,6 +49,59 @@ def test_signal_table_hides_and_marks_saved_topic_feedback():
         "⭐ Preferred",
         "Most popular",
     ]
+
+
+def test_signal_table_path_matches_raw_input_not_preapplied_frames():
+    """Tables must apply feedback after popularity sort on raw frames.
+
+    Pre-applying feedback before _prepare_topics_for_display is redundant but
+    must not change outcomes; raw frames are the intended table input.
+    """
+    topics = pd.DataFrame(
+        {
+            "Topic": [1, 2, 3],
+            LLM_TOPIC_TITLE_COLUMN: ["Most popular", "Hidden", "Preferred"],
+            "Latest_Popularity": [100, 50, 10],
+            "Documents": [["one"], ["two"], ["three"]],
+        }
+    )
+    columns = ["Topic", LLM_TOPIC_TITLE_COLUMN, "Latest_Popularity", "Documents"]
+    feedback = {2: HIDDEN_TOPIC, 3: PROMOTED_TOPIC}
+
+    from_raw = _prepare_topics_for_display(topics, columns, feedback)
+    preapplied = apply_topic_feedback(topics, feedback)
+    from_preapplied = _prepare_topics_for_display(preapplied, columns, feedback)
+
+    assert from_raw["Topic"].tolist() == [3, 1]
+    assert from_raw["Topic"].tolist() == from_preapplied["Topic"].tolist()
+    assert (
+        from_raw[LLM_TOPIC_TITLE_COLUMN].tolist()
+        == from_preapplied[LLM_TOPIC_TITLE_COLUMN].tolist()
+    )
+
+
+def test_signal_analysis_passes_raw_to_tables_and_applied_to_explore():
+    """Structural + behavioral: signal_analysis wiring matches review fix."""
+    source = Path(dashboard_signals.__file__).read_text(encoding="utf-8")
+    analysis = source.split("def signal_analysis")[1].split("def explore_topic_sources")[
+        0
+    ]
+    assert "raw_topics = get_df_topics(" in analysis
+    assert "raw_topics[NOISE]" in analysis
+    assert "raw_topics[WEAK_SIGNALS]" in analysis
+    assert "raw_topics[STRONG_SIGNALS]" in analysis
+    assert "explore_topic_sources(dfs_topics, feedback)" in analysis
+    assert "display_translated_signal_categories(" in analysis
+    # Tables must not receive the feedback-applied dict entries.
+    assert "dfs_topics[NOISE]" not in analysis
+    assert "dfs_topics[WEAK_SIGNALS]" not in analysis
+    assert "dfs_topics[STRONG_SIGNALS]" not in analysis
+
+    prepare_src = source.split("def _prepare_topics_for_display")[1].split(
+        "def display_topic_links"
+    )[0]
+    assert "sort_values" in prepare_src
+    assert "apply_topic_feedback(displayed_topics, feedback)" in prepare_src
 
 
 def test_report_picker_omits_hidden_topics_and_prioritizes_promoted_topics():


### PR DESCRIPTION
## Summary

- let users prioritize or hide topics from the Analyses tab
- persist preferences per monitoring model
- apply preferences to Trends and manual/automated reports
- add French/English labels and focused tests

Closes #85

## Testing

- `pytest -q bertrend/tests/apps` — 30 passed
- Ruff checks passed
- manually tested in the Streamlit prospective demo
