### PR TITLE
fix: bound LLM structured-output (parse) calls with a wall-clock timeout

### DIFF
--- a/.env_template
+++ b/.env_template
@@ -101,6 +101,13 @@ SMTP_USE_TLS=true
 # For sendgrid backend (example)
 SENDGRID_API_KEY=
 
+#--------------------
+# Timeouts
+#--------------------
+TOPIC_INTERPRETATION_TIMEOUT=400.0
+OPENAI_PARSE_TIMEOUT=180.0
+RABBITMQ_JOB_TIMEOUT=900
+
 # -------------------
 # Queue configuration
 # -------------------

--- a/bertrend/bertrend_apps/prospective_demo/process_new_data.py
+++ b/bertrend/bertrend_apps/prospective_demo/process_new_data.py
@@ -2,7 +2,10 @@
 #  See AUTHORS.txt
 #  SPDX-License-Identifier: MPL-2.0
 #  This file is part of BERTrend.
-from concurrent.futures import ThreadPoolExecutor, as_completed
+import math
+import os
+import time
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
 from datetime import timedelta
 from pathlib import Path
 
@@ -39,6 +42,13 @@ from bertrend.utils.data_loading import (
 )
 
 DEFAULT_TOP_K = 5
+
+# Per-topic wall-clock budget (seconds) for LLM interpretation. Bounds the wait
+# on each topic analysis so a single stalled LLM call cannot block the whole
+# interpretation step (and, through it, the queue worker) indefinitely.
+TOPIC_INTERPRETATION_TIMEOUT = float(
+    os.getenv("TOPIC_INTERPRETATION_TIMEOUT", 400.0)
+)
 
 
 class ConfigFileNotFoundError(Exception):
@@ -198,22 +208,43 @@ def generate_llm_interpretation(
 
     interpretation = []
 
-    # Use ThreadPoolExecutor for parallel processing of I/O-bound analyze_signal calls
+    # Overall wall-clock budget: roughly the number of sequential waves of
+    # concurrent tasks multiplied by the per-topic budget, so the whole step is
+    # bounded even if some topics stall.
+    if topics:
+        waves = math.ceil(len(topics) / max(1, max_workers))
+        overall_timeout = waves * TOPIC_INTERPRETATION_TIMEOUT
+    else:
+        overall_timeout = TOPIC_INTERPRETATION_TIMEOUT
+
+    # Use ThreadPoolExecutor for parallel processing of I/O-bound analyze_signal calls.
+    # cancel_futures=True (on the `with` exit) drops not-yet-started tasks rather
+    # than waiting for them, so a straggler cannot block indefinitely.
     with ThreadPoolExecutor(max_workers=max_workers) as executor:
         # Submit all topic analysis tasks
         future_to_topic = {
             executor.submit(process_topic, topic): topic for topic in topics
         }
 
-        # Collect results as they complete
-        for future in as_completed(future_to_topic):
-            topic = future_to_topic[future]
+        # Collect results, bounding the total wait so a stalled topic analysis
+        # cannot freeze the interpretation step.
+        deadline = time.monotonic() + overall_timeout
+        for future, topic in future_to_topic.items():
+            remaining = deadline - time.monotonic()
             try:
-                result = future.result()
+                result = future.result(timeout=max(0.0, remaining))
                 if result:
                     interpretation.append(result)
+            except FutureTimeoutError:
+                logger.error(
+                    f"Timed out waiting for interpretation of topic {topic} "
+                    f"after {overall_timeout:.0f}s overall budget; skipping it."
+                )
             except Exception as e:
                 logger.error(f"Exception occurred for topic {topic}: {str(e)}")
+
+        # Do not wait on any still-running/queued stragglers when leaving the block.
+        executor.shutdown(wait=False, cancel_futures=True)
 
     # Sort results by topic number to maintain consistent output order
     interpretation.sort(key=lambda x: x["topic"])

--- a/bertrend/bertrend_apps/services/queue_management/rabbitmq_config.py
+++ b/bertrend/bertrend_apps/services/queue_management/rabbitmq_config.py
@@ -39,5 +39,8 @@ class RabbitMQConfig:
     max_retries: int = int(os.getenv("RABBITMQ_MAX_RETRIES", 2))
     retry_delay: int = int(os.getenv("RABBITMQ_RETRY_DELAY", 5000))  # milliseconds
 
-    # Job timeout: max seconds a single job may run before being nacked (default: 1 hour)
-    job_timeout: int = int(os.getenv("RABBITMQ_JOB_TIMEOUT", 3600))
+    # Job timeout: max seconds a single job may run before being nacked (default: 15 min).
+    # Kept well below the previous 1 hour so a stalled job cannot block the
+    # single-slot queue for an extended period; raise via env var for genuinely
+    # long-running jobs.
+    job_timeout: int = int(os.getenv("RABBITMQ_JOB_TIMEOUT", 900))

--- a/bertrend/llm_utils/agent_utils.py
+++ b/bertrend/llm_utils/agent_utils.py
@@ -21,15 +21,28 @@ load_dotenv(override=True)
 run_config_no_tracing = RunConfig(tracing_disabled=True)
 
 
-def run_runner_sync(*args, **kwargs):
-    """Create a new event loop in a script thread (useful for Jupyter notebooks, ipython, streamlit)"""
+def run_runner_sync(*args, timeout: float | None = None, **kwargs):
+    """Run the agent ``Runner`` synchronously in a fresh event loop.
+
+    Creating a dedicated event loop makes this safe to call from threads that
+    have no running loop (Jupyter notebooks, ipython, Streamlit, or the queue
+    worker thread pool).
+
+    When ``timeout`` (seconds) is provided, the run is bounded with
+    ``asyncio.wait_for``. Because the agent performs the LLM call over async
+    HTTP, this cancellation actually tears down a stalled request instead of
+    leaving the calling thread blocked forever. A stalled request therefore
+    raises ``asyncio.TimeoutError`` (surfaced as the caller's error handling)
+    rather than silently freezing the worker and, with it, the whole queue.
+    """
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     try:
+        coro = Runner.run(*args, run_config=run_config_no_tracing, **kwargs)
+        if timeout is not None:
+            coro = asyncio.wait_for(coro, timeout=timeout)
         # If Runner.run is async, run it to completion
-        return loop.run_until_complete(
-            Runner.run(*args, run_config=run_config_no_tracing, **kwargs)
-        )
+        return loop.run_until_complete(coro)
     finally:
         loop.close()
 

--- a/bertrend/llm_utils/openai_client.py
+++ b/bertrend/llm_utils/openai_client.py
@@ -8,19 +8,23 @@ import re
 from enum import Enum
 from typing import Type
 
-from agents import ModelSettings, Runner
+from agents import ModelSettings
 from loguru import logger
 from openai import OpenAI, Stream, Timeout
 from openai.types import Reasoning
 from openai.types.chat import ChatCompletion, ChatCompletionChunk
 from pydantic import BaseModel
 
-from bertrend.llm_utils.agent_utils import BaseAgentFactory, run_config_no_tracing
+from bertrend.llm_utils.agent_utils import BaseAgentFactory, run_runner_sync
 
 # Note: .env is loaded in bertrend/__init__.py which is imported before this module
 
 MAX_ATTEMPTS = 3
 TIMEOUT = 60.0
+# Wall-clock timeout (seconds) for a single structured-output (parse) call.
+# Generous enough for reasoning models, but bounded so that a stalled
+# connection can never hang the worker (and therefore the whole queue).
+PARSE_TIMEOUT = float(os.getenv("OPENAI_PARSE_TIMEOUT", 180.0))
 DEFAULT_TEMPERATURE = 0.1
 DEFAULT_MODEL = "gpt-4.1-mini"
 
@@ -214,11 +218,14 @@ class OpenAI_Client:
 
         parsing_agent = BaseAgentFactory(model_name=model).create_agent(**agent_kwargs)
 
-        # invoke agent
-        result = Runner.run_sync(
+        # Invoke agent with a bounded wall-clock timeout so a stalled LLM
+        # connection cannot block the caller indefinitely. On timeout this
+        # raises asyncio.TimeoutError, which callers already handle by
+        # logging and returning None instead of freezing the queue worker.
+        result = run_runner_sync(
             input=user_prompt,
             starting_agent=parsing_agent,
-            run_config=run_config_no_tracing,
+            timeout=PARSE_TIMEOUT,
         )
         response = (
             result.final_output if hasattr(result, "final_output") else str(result)

--- a/bertrend/tests/llm/test_openai_client.py
+++ b/bertrend/tests/llm/test_openai_client.py
@@ -10,8 +10,7 @@ import pytest
 from openai import Stream
 from pydantic import BaseModel
 
-from bertrend.llm_utils.agent_utils import run_config_no_tracing
-from bertrend.llm_utils.openai_client import APIType, OpenAI_Client
+from bertrend.llm_utils.openai_client import APIType, OpenAI_Client, PARSE_TIMEOUT
 
 
 @pytest.fixture
@@ -118,7 +117,7 @@ def test_parse_basic_functionality(mock_api_key):
             return_value=mock_factory,
         ) as mock_factory_cls,
         patch(
-            "bertrend.llm_utils.openai_client.Runner.run_sync",
+            "bertrend.llm_utils.openai_client.run_runner_sync",
             return_value=mock_result,
         ) as mock_run_sync,
     ):
@@ -135,7 +134,7 @@ def test_parse_basic_functionality(mock_api_key):
         mock_run_sync.assert_called_once_with(
             input="What is the weather today?",
             starting_agent=mock_agent,
-            run_config=run_config_no_tracing,
+            timeout=PARSE_TIMEOUT,
         )
 
 
@@ -155,7 +154,7 @@ def test_parse_with_system_prompt(mock_api_key):
             return_value=mock_factory,
         ) as mock_factory_cls,
         patch(
-            "bertrend.llm_utils.openai_client.Runner.run_sync",
+            "bertrend.llm_utils.openai_client.run_runner_sync",
             return_value=mock_result,
         ) as mock_run_sync,
     ):
@@ -174,7 +173,7 @@ def test_parse_with_system_prompt(mock_api_key):
         mock_run_sync.assert_called_once_with(
             input="What is the weather today?",
             starting_agent=mock_agent,
-            run_config=run_config_no_tracing,
+            timeout=PARSE_TIMEOUT,
         )
 
 
@@ -191,7 +190,7 @@ def test_parse_error_handling(mock_api_key):
             return_value=mock_factory,
         ),
         patch(
-            "bertrend.llm_utils.openai_client.Runner.run_sync",
+            "bertrend.llm_utils.openai_client.run_runner_sync",
             side_effect=Exception("API Parse Error"),
         ),
         pytest.raises(Exception, match="API Parse Error"),
@@ -215,7 +214,7 @@ def test_parse_with_none_response_format(mock_api_key):
             return_value=mock_factory,
         ) as mock_factory_cls,
         patch(
-            "bertrend.llm_utils.openai_client.Runner.run_sync",
+            "bertrend.llm_utils.openai_client.run_runner_sync",
             return_value=mock_result,
         ) as mock_run_sync,
     ):
@@ -230,7 +229,7 @@ def test_parse_with_none_response_format(mock_api_key):
         mock_run_sync.assert_called_once_with(
             input="What is the weather today?",
             starting_agent=mock_agent,
-            run_config=run_config_no_tracing,
+            timeout=PARSE_TIMEOUT,
         )
         assert result == mock_parsed
 
@@ -250,7 +249,7 @@ def test_parse_includes_model_settings_for_gpt5(mock_api_key):
             return_value=mock_factory,
         ) as mock_factory_cls,
         patch(
-            "bertrend.llm_utils.openai_client.Runner.run_sync",
+            "bertrend.llm_utils.openai_client.run_runner_sync",
             return_value=mock_result,
         ),
     ):


### PR DESCRIPTION
The OpenAI_Client.parse() path (used for all topic/signal LLM interpretation)
ran Runner.run_sync() without any timeout, bypassing the timeout and retry
configuration applied to the OpenAI_Client used by generate(). When a
connection stalled (as opposed to erroring), the call could hang for a very
long time, freezing the single-slot queue worker and blocking the whole
execution queue.

parse() now runs the agent through run_runner_sync() with a configurable
wall-clock timeout (OPENAI_PARSE_TIMEOUT, default 180s). Because the agent
performs the LLM call over async HTTP, asyncio.wait_for actually cancels a
stalled request and tears the connection down. On timeout it raises, which
callers already handle by logging and returning None.
